### PR TITLE
Add backwards compatible velocity error

### DIFF
--- a/napytau/import_export/dataset_factory/napatau_dataset_factory.py
+++ b/napytau/import_export/dataset_factory/napatau_dataset_factory.py
@@ -21,7 +21,7 @@ class NapatauDatasetFactory:
         )
 
     @staticmethod
-    def parse_velocity(velocity_rows: List[str]) -> RelativeVelocity:
+    def parse_velocity(velocity_rows: List[str]) -> ValueErrorPair[RelativeVelocity]:
         filtered_velocities = list(
             filter(lambda x: not x.startswith("#"), velocity_rows)
         )
@@ -31,7 +31,26 @@ class NapatauDatasetFactory:
                 f"Expected one velocity row, but got {len(filtered_velocities)}"
             )
 
-        return RelativeVelocity(float(filtered_velocities[0]))
+        split_velocity_row = filtered_velocities[0].split(" ")
+
+        if len(split_velocity_row) < 1:
+            raise ValueError(
+                f"Expected at least 1 value in velocity row, but got {len(split_velocity_row)}"  # noqa E501
+            )
+
+        if len(split_velocity_row) > 2:
+            raise ValueError(
+                f"Expected at most 1 value in velocity row, but got {len(split_velocity_row)}"  # noqa E501
+            )
+
+        velocity = float(split_velocity_row[0])
+        velocity_error = (
+            float(split_velocity_row[1]) if len(split_velocity_row) == 2 else 0.0
+        )
+
+        return ValueErrorPair(
+            RelativeVelocity(velocity), RelativeVelocity(velocity_error)
+        )
 
     @staticmethod
     def parse_datapoints(

--- a/napytau/import_export/model/dataset.py
+++ b/napytau/import_export/model/dataset.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from napytau.import_export.model.datapoint_collection import DatapointCollection
 from napytau.import_export.model.relative_velocity import RelativeVelocity
+from napytau.util.model.value_error_pair import ValueErrorPair
 
 
 @dataclass
@@ -11,10 +12,10 @@ class DataSet:
     A dataset represents the entirety of the data collected from a single observation.
     """
 
-    relative_velocity: RelativeVelocity
+    relative_velocity: ValueErrorPair[RelativeVelocity]
     datapoints: DatapointCollection
 
-    def get_relative_velocity(self) -> RelativeVelocity:
+    def get_relative_velocity(self) -> ValueErrorPair[RelativeVelocity]:
         return self.relative_velocity
 
     def get_datapoints(self) -> DatapointCollection:

--- a/tests/import_export/dataset_factory/napatau_dataset_factory_test.py
+++ b/tests/import_export/dataset_factory/napatau_dataset_factory_test.py
@@ -79,8 +79,10 @@ class NapatauDatasetFactoryUnitTest(unittest.TestCase):
                 )
             )
 
-    def test_raisesAnExceptionIfAFitRowWithTooManyValuesForASetOfBasicIntensitiesButTooManyForASetOfBasicAndShiftedIntensitiesIsProvided(self): # noqa: E501
-        """Raises an exception if a fit row with too many values for a set of basic intensities but too many for a set of basic and shifted intensities is provided""" # noqa: E501
+    def test_raisesAnExceptionIfAFitRowWithTooManyValuesForASetOfBasicIntensitiesButTooManyForASetOfBasicAndShiftedIntensitiesIsProvided(  # noqa: E501
+        self,
+    ):
+        """Raises an exception if a fit row with too many values for a set of basic intensities but too many for a set of basic and shifted intensities is provided"""  # noqa: E501
         with self.assertRaises(ValueError):
             NapatauDatasetFactory.create_dataset(
                 RawNapatauData(
@@ -114,7 +116,8 @@ class NapatauDatasetFactoryUnitTest(unittest.TestCase):
             )
         )
 
-        self.assertEqual(dataset.relative_velocity.get_velocity(), 1)
+        self.assertEqual(dataset.relative_velocity.value.get_velocity(), 1)
+        self.assertEqual(dataset.relative_velocity.error.get_velocity(), 0)
         self.assertEqual(len(dataset.datapoints.as_dict()), 1)
         self.assertEqual(
             dataset.datapoints.get_datapoint_by_distance(1).distance.value, 1
@@ -152,7 +155,8 @@ class NapatauDatasetFactoryUnitTest(unittest.TestCase):
             )
         )
 
-        self.assertEqual(dataset.relative_velocity.get_velocity(), 1)
+        self.assertEqual(dataset.relative_velocity.value.get_velocity(), 1)
+        self.assertEqual(dataset.relative_velocity.error.get_velocity(), 0)
         self.assertEqual(len(dataset.datapoints.as_dict()), 1)
         self.assertEqual(
             dataset.datapoints.get_datapoint_by_distance(1).distance.value, 1
@@ -202,6 +206,21 @@ class NapatauDatasetFactoryUnitTest(unittest.TestCase):
             ).feeding_unshifted_intensity.error,
             1,
         )
+
+    def test_createsADatasetFromValidDataWithAVelocityErrorGiven(self):
+        """Creates a dataset from valid data with a velocity error given"""
+        dataset = NapatauDatasetFactory.create_dataset(
+            RawNapatauData(
+                ["1 1"],
+                ["1 1 1"],
+                ["1 1 1 1 1"],
+                ["1 1 1"],
+            )
+        )
+
+        self.assertEqual(dataset.relative_velocity.value.get_velocity(), 1)
+        self.assertEqual(dataset.relative_velocity.error.get_velocity(), 1)
+        self.assertEqual(len(dataset.datapoints.as_dict()), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Please remove any superfluous sections before submitting the pull request! -->

### Summary

This adds a velocity error value to the data model, it also implements reading this value from the napatau data format. This is done in a backwards compatible fashion, so as to not break compatibility with previously generated files.

---

### PR checklist

- [x] I have written tests that fail without my changes. _Or I did not add them on purpose._
- [x] I have included instructions on how to test this, assuming they are not already apparent from the linked issue.

---

### Closes/Fixes/Related to

<!-- Links/references to issues this PR addresses. See https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords for more info. -->
* Closes #24  <!-- If #0 is an enhancement issue -->

## How to Test

- Currently we will have to trust the CI
- If #22 is merged before the test of this, you can used the headless mode to read a file containing a velocity error value.