### PR TITLE
chore: Raise minimum matplotlib version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "customtkinter>=5.2.2",
-    "matplotlib>=3.9.2",
+    "matplotlib>=3.10.0",
 ]
 
 [build-system]


### PR DESCRIPTION
<!-- Please remove any superfluous sections before submitting the pull request! -->

### Summary

This raises the minimum required matplotlib version to `3.10.0`, as the versions before are incompatible with tcl-tk > `9.0.0` which is bundled as the default tcl package for our minimum required python version `3.12` on Unix Systems (Linux/MacOS).