### PR TITLE
Remove multi data set import

### DIFF
--- a/napytau/headless/headless_mockup.py
+++ b/napytau/headless/headless_mockup.py
@@ -1,5 +1,4 @@
 from pathlib import PurePath
-from typing import List
 
 from napytau.cli.cli_arguments import CLIArguments
 from napytau.import_export.import_export import (
@@ -20,80 +19,46 @@ def init(cli_arguments: CLIArguments) -> None:
 
         fit_file_path = cli_arguments.get_fit_file_path()
 
-        datasets: List[DataSet] = import_legacy_format_from_files(
+        dataset: DataSet = import_legacy_format_from_files(
             PurePath(setup_files_directory_path),
             PurePath(fit_file_path) if fit_file_path else None,
         )
 
-        for dataset in datasets:
-            print("Dataset:")
-            print(f"  Velocity: {dataset.relative_velocity.value.get_velocity()}")
-            print(f"  Velocity Error: {dataset.relative_velocity.error.get_velocity()}")
-            for datapoint in dataset.datapoints:
-                print("  Datapoint:")
-                print(
-                    f"    Distance: Value: {datapoint.get_distance().value} "
-                    f"Error: {datapoint.get_distance().error}"
-                )
-                print(
-                    f"    Calibration: Value: {datapoint.get_calibration().value} "
-                    f"Error: {datapoint.get_calibration().error}"
-                )
-                shifted_intensity, unshifted_intensity = datapoint.get_intensity()
-                print(
-                    f"    Shifted Intensity: Value: {shifted_intensity.value} "
-                    f"Error: {shifted_intensity.error}"
-                )
-                print(
-                    f"    Unshifted Intensity: Value: {unshifted_intensity.value} "
-                    f"Error: {unshifted_intensity.error}"
-                )
-                print(f"    Active:  {datapoint.is_active()} ")
-                print("-" * 80)
-            print("=" * 80)
+        print("Dataset:")
+        print(f"  Velocity: {dataset.relative_velocity.value.get_velocity()}")
+        print(f"  Velocity Error: {dataset.relative_velocity.error.get_velocity()}")
+        for datapoint in dataset.datapoints:
+            print("  Datapoint:")
+            print(
+                f"    Distance: Value: {datapoint.get_distance().value} "
+                f"Error: {datapoint.get_distance().error}"
+            )
+            print(
+                f"    Calibration: Value: {datapoint.get_calibration().value} "
+                f"Error: {datapoint.get_calibration().error}"
+            )
+            shifted_intensity, unshifted_intensity = datapoint.get_intensity()
+            print(
+                f"    Shifted Intensity: Value: {shifted_intensity.value} "
+                f"Error: {shifted_intensity.error}"
+            )
+            print(
+                f"    Unshifted Intensity: Value: {unshifted_intensity.value} "
+                f"Error: {unshifted_intensity.error}"
+            )
+            print(f"    Active:  {datapoint.is_active()} ")
+            print("-" * 80)
+        print("=" * 80)
 
         setup_file_path = cli_arguments.get_setup_identifier()
         if setup_file_path is not None:
-            for dataset in datasets:
-                read_legacy_setup_data_into_data_set(dataset, PurePath(setup_file_path))
-
-                print("Dataset:")
-                print(f"  Velocity: {dataset.relative_velocity.value.get_velocity()}")
-                print(
-                    f"  Velocity Error: {dataset.relative_velocity.error.get_velocity()}"  # noqa: E501
-                )
-                print(f"  Tau factor: {dataset.get_tau_factor()}")
-                print(f"  Polynomial count: {dataset.get_polynomial_count()}")
-
-                for index, sampling_point in enumerate(
-                    coalesce(dataset.get_sampling_points(), [])
-                ):
-                    print(f"  Sampling point #{index}: {sampling_point}")
-
-                for datapoint in dataset.datapoints:
-                    print("  Datapoint:")
-                    print(
-                        f"    Distance: Value: {datapoint.get_distance().value} "
-                        f"Error: {datapoint.get_distance().error}"
-                    )
-                    print(f"    Active:  {datapoint.is_active()} ")
-                    print("-" * 80)
-                print("=" * 80)
-    elif cli_arguments.get_dataset_format() == IMPORT_FORMAT_NAPYTAU:
-        setup_files_directory_path = cli_arguments.get_data_files_directory_path()
-        setup_identifier = cli_arguments.get_setup_identifier()
-
-        for dataset, raw_setups in import_napytau_format_from_files(
-            PurePath(setup_files_directory_path)
-        ):
-            if setup_identifier is not None:
-                read_napytau_setup_data_into_data_set(
-                    dataset, raw_setups, setup_identifier
-                )
+            read_legacy_setup_data_into_data_set(dataset, PurePath(setup_file_path))
 
             print("Dataset:")
             print(f"  Velocity: {dataset.relative_velocity.value.get_velocity()}")
-            print(f"  Velocity Error: {dataset.relative_velocity.error.get_velocity()}")
+            print(
+                f"  Velocity Error: {dataset.relative_velocity.error.get_velocity()}"  # noqa: E501
+            )
             print(f"  Tau factor: {dataset.get_tau_factor()}")
             print(f"  Polynomial count: {dataset.get_polynomial_count()}")
 
@@ -108,24 +73,54 @@ def init(cli_arguments: CLIArguments) -> None:
                     f"    Distance: Value: {datapoint.get_distance().value} "
                     f"Error: {datapoint.get_distance().error}"
                 )
-                print(
-                    f"    Calibration: Value: {datapoint.get_calibration().value} "
-                    f"Error: {datapoint.get_calibration().error}"
-                )
-                shifted_intensity, unshifted_intensity = datapoint.get_intensity()
-                print(
-                    f"    Shifted Intensity: Value: {shifted_intensity.value} "
-                    f"Error: {shifted_intensity.error}"
-                )
-                print(
-                    f"    Unshifted Intensity: Value: {unshifted_intensity.value} "
-                    f"Error: {unshifted_intensity.error}"
-                )
-                print(
-                    f"    Distance: Value: {datapoint.get_distance().value} "
-                    f"Error: {datapoint.get_distance().error}"
-                )
                 print(f"    Active:  {datapoint.is_active()} ")
+                print("-" * 80)
+            print("=" * 80)
+    elif cli_arguments.get_dataset_format() == IMPORT_FORMAT_NAPYTAU:
+        setup_files_directory_path = cli_arguments.get_data_files_directory_path()
+        setup_identifier = cli_arguments.get_setup_identifier()
+
+        (dataset, raw_setups) = import_napytau_format_from_files(
+            PurePath(setup_files_directory_path)
+        )
+        if setup_identifier is not None:
+            read_napytau_setup_data_into_data_set(dataset, raw_setups, setup_identifier)
+
+        print("Dataset:")
+        print(f"  Velocity: {dataset.relative_velocity.value.get_velocity()}")
+        print(f"  Velocity Error: {dataset.relative_velocity.error.get_velocity()}")
+        print(f"  Tau factor: {dataset.get_tau_factor()}")
+        print(f"  Polynomial count: {dataset.get_polynomial_count()}")
+
+        for index, sampling_point in enumerate(
+            coalesce(dataset.get_sampling_points(), [])
+        ):
+            print(f"  Sampling point #{index}: {sampling_point}")
+
+        for datapoint in dataset.datapoints:
+            print("  Datapoint:")
+            print(
+                f"    Distance: Value: {datapoint.get_distance().value} "
+                f"Error: {datapoint.get_distance().error}"
+            )
+            print(
+                f"    Calibration: Value: {datapoint.get_calibration().value} "
+                f"Error: {datapoint.get_calibration().error}"
+            )
+            shifted_intensity, unshifted_intensity = datapoint.get_intensity()
+            print(
+                f"    Shifted Intensity: Value: {shifted_intensity.value} "
+                f"Error: {shifted_intensity.error}"
+            )
+            print(
+                f"    Unshifted Intensity: Value: {unshifted_intensity.value} "
+                f"Error: {unshifted_intensity.error}"
+            )
+            print(
+                f"    Distance: Value: {datapoint.get_distance().value} "
+                f"Error: {datapoint.get_distance().error}"
+            )
+            print(f"    Active:  {datapoint.is_active()} ")
     else:
         raise ValueError(
             f"Unknown dataset format: {cli_arguments.get_dataset_format()}"

--- a/napytau/import_export/crawler/crawler.py
+++ b/napytau/import_export/crawler/crawler.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from typing import List
 
 
 class Crawler[T, U]:
@@ -12,7 +11,7 @@ class Crawler[T, U]:
     """
 
     @abstractmethod
-    def crawl(self, resource_identifier: T) -> List[U]:
+    def crawl(self, resource_identifier: T) -> U:
         """
         Crawls from a base resource identifier and returns a list of lists of resources.
         This is intended to allow the user to specify a base resource identifier

--- a/napytau/import_export/import_export.py
+++ b/napytau/import_export/import_export.py
@@ -27,10 +27,10 @@ IMPORT_FORMATS = [IMPORT_FORMAT_LEGACY, IMPORT_FORMAT_NAPYTAU]
 
 def import_legacy_format_from_files(
     directory_path: PurePath, fit_file_path: Optional[PurePath] = None
-) -> List[DataSet]:
+) -> DataSet:
     """
     Ingests a dataset from the Legacy format. The directory path will be
-    recursively searched for the following files:
+    searched for the following files:
     - v_c
     - distances.dat
     - norm.fac
@@ -42,19 +42,14 @@ def import_legacy_format_from_files(
 
     file_crawler = _configure_file_crawler_for_legacy_format(fit_file_path)
 
-    setup_file_bundles: List[LegacySetupFiles] = file_crawler.crawl(directory_path)
+    setup_files: LegacySetupFiles = file_crawler.crawl(directory_path)
 
-    return list(
-        map(
-            lambda setup_files: LegacyFactory.create_dataset(
-                RawLegacyData(
-                    FileReader.read_rows(setup_files.velocity_file),
-                    FileReader.read_rows(setup_files.distances_file),
-                    FileReader.read_rows(setup_files.fit_file),
-                    FileReader.read_rows(setup_files.calibration_file),
-                )
-            ),
-            setup_file_bundles,
+    return LegacyFactory.create_dataset(
+        RawLegacyData(
+            FileReader.read_rows(setup_files.velocity_file),
+            FileReader.read_rows(setup_files.distances_file),
+            FileReader.read_rows(setup_files.fit_file),
+            FileReader.read_rows(setup_files.calibration_file),
         )
     )
 
@@ -101,7 +96,7 @@ def read_legacy_setup_data_into_data_set(
 
 def import_napytau_format_from_files(
     directory_path: PurePath,
-) -> List[Tuple[DataSet, List[dict]]]:
+) -> Tuple[DataSet, List[dict]]:
     """
     Ingests a dataset from the NapyTau format. The directory path will be
     recursively searched for the following files:
@@ -117,14 +112,9 @@ def import_napytau_format_from_files(
         lambda files: files[0],
     )
 
-    napytau_file_paths = file_crawler.crawl(directory_path)
+    napytau_file_path = file_crawler.crawl(directory_path)
 
-    return list(
-        map(
-            lambda napytau_file_path: _map_raw_napytau_data(napytau_file_path),
-            napytau_file_paths,
-        )
-    )
+    return _map_raw_napytau_data(napytau_file_path)
 
 
 def _map_raw_napytau_data(napytau_file_path: PurePath) -> Tuple[DataSet, List[dict]]:

--- a/tests/import_export/crawler/file_crawler_test.py
+++ b/tests/import_export/crawler/file_crawler_test.py
@@ -3,6 +3,8 @@ from pathlib import PurePath
 from re import compile
 from unittest.mock import MagicMock, patch
 
+from napytau.import_export.import_export_error import ImportExportError
+
 
 def set_up_mocks() -> (
     MagicMock,
@@ -52,28 +54,8 @@ class FileCrawlerUnitTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 file_crawler.crawl(PurePath("not_a_directory"))
 
-    def test_returnsEmptyArrayIfProvidedDirectoryEmpty(self):
-        """Returns an empty array if the provided directory is empty"""
-        os_module_mock, re_module_mock, walk_mock, path_mock, isdir_mock, _ = (
-            set_up_mocks()
-        )
-        isdir_mock.return_value = True
-        walk_mock.return_value = []
-        with patch.dict(
-            "sys.modules",
-            {
-                "os": os_module_mock,
-                "re": re_module_mock,
-                "os.path": path_mock,
-            },
-        ):
-            from napytau.import_export.crawler.file_crawler import FileCrawler
-
-            file_crawler = FileCrawler([], lambda x: x)
-            self.assertEqual(file_crawler.crawl(PurePath("some/directory")), [])
-
-    def test_doesNotAddFilesIfNoFilesMatchThePattern(self):
-        """Does not add files if no files match the pattern"""
+    def test_raisesErrorIfTheProvidedDirectoryDoesNotContainAllRequiredFiles(self):
+        """Raises an error if the provided directory does not contain all required files"""
         (
             os_module_mock,
             re_module_mock,
@@ -83,8 +65,7 @@ class FileCrawlerUnitTest(unittest.TestCase):
             regex_match_mock,
         ) = set_up_mocks()
         isdir_mock.return_value = True
-        walk_mock.return_value = [("root", [], ["file1", "file2"])]
-        regex_match_mock.return_value = False
+        walk_mock.return_value = [("some/directory", [], [])]
         with patch.dict(
             "sys.modules",
             {
@@ -95,10 +76,9 @@ class FileCrawlerUnitTest(unittest.TestCase):
         ):
             from napytau.import_export.crawler.file_crawler import FileCrawler
 
-            file_crawler = FileCrawler(
-                [compile("pattern1"), compile("pattern2")], lambda x: x
-            )
-            self.assertEqual(file_crawler.crawl(PurePath("some/directory")), [])
+            file_crawler = FileCrawler([compile("pattern1"), compile("pattern2")], lambda x: x)
+            with self.assertRaises(ImportExportError):
+                file_crawler.crawl(PurePath("some/directory"))
 
     def test_addsFilesIfFilesMatchThePatternAndMapsThemWithTheProvidedFactory(self):
         """Adds files if files match the pattern and maps them with the provided factory"""  # noqa: E501
@@ -111,7 +91,7 @@ class FileCrawlerUnitTest(unittest.TestCase):
             regex_match_mock,
         ) = set_up_mocks()
         isdir_mock.return_value = True
-        walk_mock.return_value = [("root", [], ["file1", "file2"])]
+        walk_mock.return_value = [("some/directory", [], ["file1", "file2"])]
         regex_match_mock.side_effect = lambda pattern, file: file == "file2"
         with patch.dict(
             "sys.modules",
@@ -124,16 +104,16 @@ class FileCrawlerUnitTest(unittest.TestCase):
             from napytau.import_export.crawler.file_crawler import FileCrawler
 
             factory_mock = MagicMock()
-            factory_mock.return_value = ["root/file2"]
+            factory_mock.return_value = ["some/directory/file2"]
 
             file_crawler = FileCrawler(
                 [compile("pattern1"), compile("pattern2")], factory_mock
             )
             self.assertEqual(
-                file_crawler.crawl(PurePath("some/directory")), [["root/file2"]]
+                file_crawler.crawl(PurePath("some/directory")), ["some/directory/file2"]
             )
             self.assertEqual(
-                factory_mock.mock_calls[0].args, ([PurePath("root/file2")],)
+                factory_mock.mock_calls[0].args, ([PurePath("some/directory/file2")],)
             )
 
 

--- a/tests/import_export/import_export_test.py
+++ b/tests/import_export/import_export_test.py
@@ -167,14 +167,12 @@ class IngestUnitTest(unittest.TestCase):
         file_crawler_module_mock.FileCrawler.return_value = (
             file_crawler_module_mock.FileCrawler
         )
-        file_crawler_module_mock.FileCrawler.crawl.return_value = [
-            LegacySetupFiles(
-                PurePath("test_distances.dat"),
-                PurePath("test_v_c"),
-                PurePath("test_fit"),
-                PurePath("test_norm.fac"),
-            )
-        ]
+        file_crawler_module_mock.FileCrawler.crawl.return_value = LegacySetupFiles(
+            PurePath("test_distances.dat"),
+            PurePath("test_v_c"),
+            PurePath("test_fit"),
+            PurePath("test_norm.fac"),
+        )
 
         with patch.dict(
             "sys.modules",
@@ -223,14 +221,12 @@ class IngestUnitTest(unittest.TestCase):
         file_crawler_module_mock.FileCrawler.return_value = (
             file_crawler_module_mock.FileCrawler
         )
-        file_crawler_module_mock.FileCrawler.crawl.return_value = [
-            LegacySetupFiles(
-                PurePath("test_distances.dat"),
-                PurePath("test_v_c"),
-                PurePath("test_fit"),
-                PurePath("test_norm.fac"),
-            )
-        ]
+        file_crawler_module_mock.FileCrawler.crawl.return_value = LegacySetupFiles(
+            PurePath("test_distances.dat"),
+            PurePath("test_v_c"),
+            PurePath("test_fit"),
+            PurePath("test_norm.fac"),
+        )
         file_reader_module_mock.FileReader.read_rows.side_effect = [
             ["v_c_row"],
             ["distances.dat_row"],
@@ -293,14 +289,12 @@ class IngestUnitTest(unittest.TestCase):
         file_crawler_module_mock.FileCrawler.return_value = (
             file_crawler_module_mock.FileCrawler
         )
-        file_crawler_module_mock.FileCrawler.crawl.return_value = [
-            LegacySetupFiles(
-                PurePath("test_distances.dat"),
-                PurePath("test_v_c"),
-                PurePath("test_fit"),
-                PurePath("test_norm.fac"),
-            )
-        ]
+        file_crawler_module_mock.FileCrawler.crawl.return_value = LegacySetupFiles(
+            PurePath("test_distances.dat"),
+            PurePath("test_v_c"),
+            PurePath("test_fit"),
+            PurePath("test_norm.fac"),
+        )
         file_reader_module_mock.FileReader.read_rows.side_effect = [
             ["v_c_row"],
             ["distances.dat_row"],
@@ -496,9 +490,7 @@ class IngestUnitTest(unittest.TestCase):
         file_crawler_module_mock.FileCrawler.return_value = (
             file_crawler_module_mock.FileCrawler
         )
-        file_crawler_module_mock.FileCrawler.crawl.return_value = [
-            PurePath("test.napytau.json")
-        ]
+        file_crawler_module_mock.FileCrawler.crawl.return_value = PurePath("test.napytau.json")
 
         with patch.dict(
             "sys.modules",
@@ -624,15 +616,15 @@ class IngestUnitTest(unittest.TestCase):
             )
 
             self.assertEqual(
-                result[0][0].relative_velocity.value.velocity,
+                result[0].relative_velocity.value.velocity,
                 1,
             )
             self.assertEqual(
-                result[0][0].relative_velocity.error.velocity,
+                result[0].relative_velocity.error.velocity,
                 0.1,
             )
             self.assertEqual(
-                result[0][1],
+                result[1],
                 ["setup1", "setup2"],
             )
 


### PR DESCRIPTION
<!-- Please remove any superfluous sections before submitting the pull request! -->

### Summary

Remove automatic recursive walking of directories when importing datasets in all modes. This is done to simplify the interface of the import export module, as the feature didn't prove important enough to justify the complication of the interface.

---

### PR checklist

- [x] I have written tests that fail without my changes. _Or I did not add them on purpose._
- [x] I have included instructions on how to test this, assuming they are not already apparent from the linked issue.

---