### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "napytau"
-version = "0.1.0"
+version = "1.0.0"
 description = "A modern reimplementation of napatau"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "napytau"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "customtkinter" },


### PR DESCRIPTION
This prepares the release of the first major version of Napytau 🥳. This represents the culmination of the work on this Software in the duration of the BP module at TU Darmstadt. Since there is still work to be done, future versions will be developed as an open source project. The repository will move to the RWTH Aachen GitLab.