### PR TITLE
Core/tau simple

### DIFF
--- a/napytau/cli/cli_arguments.py
+++ b/napytau/cli/cli_arguments.py
@@ -11,6 +11,7 @@ class CLIArguments:
     data_files_directory: str
     fit_file_path: Optional[str]
     setup_identifier: Optional[str]
+    simple_tau: bool
 
     def __init__(self, raw_args: Namespace):
         self.headless = coalesce(raw_args.headless, False)
@@ -18,6 +19,7 @@ class CLIArguments:
         self.data_files_directory = coalesce(raw_args.data_files_directory, getcwd())
         self.fit_file_path = raw_args.fit_file
         self.setup_identifier = raw_args.setup_identifier
+        self.simple_tau = raw_args.simple_tau
 
     def is_headless(self) -> bool:
         return self.headless
@@ -33,3 +35,6 @@ class CLIArguments:
 
     def get_setup_identifier(self) -> Optional[str]:
         return self.setup_identifier
+
+    def is_simple_tau(self) -> bool:
+        return self.simple_tau

--- a/napytau/cli/cli_arguments.py
+++ b/napytau/cli/cli_arguments.py
@@ -19,7 +19,7 @@ class CLIArguments:
         self.data_files_directory = coalesce(raw_args.data_files_directory, getcwd())
         self.fit_file_path = raw_args.fit_file
         self.setup_identifier = raw_args.setup_identifier
-        self.simple_tau = raw_args.simple_tau
+        self.tau_simple = raw_args.tau_simple
 
     def is_headless(self) -> bool:
         return self.headless
@@ -36,5 +36,5 @@ class CLIArguments:
     def get_setup_identifier(self) -> Optional[str]:
         return self.setup_identifier
 
-    def is_simple_tau(self) -> bool:
-        return self.simple_tau
+    def is_tau_simple(self) -> bool:
+        return self.tau_simple

--- a/napytau/cli/cli_arguments.py
+++ b/napytau/cli/cli_arguments.py
@@ -1,8 +1,8 @@
 from os import getcwd
 from typing import Optional
+from argparse import Namespace
 
 from napytau.util.coalesce import coalesce
-from argparse import Namespace
 
 
 class CLIArguments:

--- a/napytau/cli/parser.py
+++ b/napytau/cli/parser.py
@@ -36,5 +36,8 @@ def parse_cli_arguments() -> CLIArguments:
         help="""Identifier of the setup to use with the dataset, file path for legacy
         format, or setup name for NaPyTau format""",
     )
+    parser.add_argument(
+        "--simple_tau", action="store_true", help="Calculate a first estimate of tau."
+    )
 
     return CLIArguments(parser.parse_args())

--- a/napytau/cli/parser.py
+++ b/napytau/cli/parser.py
@@ -37,7 +37,7 @@ def parse_cli_arguments() -> CLIArguments:
         format, or setup name for NaPyTau format""",
     )
     parser.add_argument(
-        "--simple_tau", action="store_true", help="Calculate a first estimate of tau."
+        "--tau_simple", action="store_true", help="Calculate a first estimate of tau."
     )
 
     return CLIArguments(parser.parse_args())

--- a/napytau/core/core.py
+++ b/napytau/core/core.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 from napytau.core.chi import optimize_tau_factor
 from napytau.core.polynomials import (
     calculate_polynomial_coefficients_for_fit,
@@ -6,9 +7,8 @@ from napytau.core.polynomials import (
 from napytau.core.tau import calculate_tau_i_values
 from napytau.core.delta_tau import calculate_error_propagation_terms
 from napytau.core.tau_final import calculate_tau_final
-from typing import Tuple
-import numpy as np
 from napytau.import_export.model.dataset import DataSet
+import numpy as np
 
 
 def calculate_lifetime_for_fit(

--- a/napytau/core/delta_tau.py
+++ b/napytau/core/delta_tau.py
@@ -1,11 +1,12 @@
+import numpy as np
+import autograd as ag
+
 from napytau.core.polynomials import (
     evaluate_differentiated_polynomial_at_measuring_times,
     evaluate_polynomial_at_measuring_time,
 )
-import numpy as np
-import autograd as ag
-
 from napytau.import_export.model.dataset import DataSet
+
 
 def calculate_covariance_matrix(
     dataset: DataSet,
@@ -24,12 +25,16 @@ def calculate_covariance_matrix(
     """
 
     datapoints = dataset.get_datapoints()
-    
+
     evaluate_polynomial = ag.jacobian(
-        lambda coefficients_x, distance: evaluate_polynomial_at_measuring_time(dataset, distance, coefficients_x),
+        lambda coefficients_x, distance: evaluate_polynomial_at_measuring_time(
+            dataset, distance, coefficients_x
+        ),
         argnum=1,
     )
-    jacobian_matrix: np.ndarray = evaluate_polynomial(coefficients, datapoints.get_distances().get_values())
+    jacobian_matrix: np.ndarray = evaluate_polynomial(
+        coefficients, datapoints.get_distances().get_values()
+    )
     # Construct the weight matrix from the inverse squared errors
     weight_matrix: np.ndarray = np.diag(
         1 / np.power(datapoints.get_shifted_intensities().get_errors(), 2)

--- a/napytau/core/polynomials.py
+++ b/napytau/core/polynomials.py
@@ -1,12 +1,15 @@
-from napytau.core.errors.polynomial_coefficient_error import (
-    PolynomialCoefficientError,
-)
 import numpy as np
 import scipy as sp
 
-from napytau.core.time import calculate_time_from_distance_and_relative_velocity, \
-    calculate_times_from_distances_and_relative_velocity
+from napytau.core.errors.polynomial_coefficient_error import (
+    PolynomialCoefficientError,
+)
+from napytau.core.time import (
+    calculate_time_from_distance_and_relative_velocity,
+    calculate_times_from_distances_and_relative_velocity,
+)
 from napytau.import_export.model.dataset import DataSet
+
 
 def evaluate_polynomial_at_measuring_times(
     dataset: DataSet,
@@ -40,9 +43,9 @@ def evaluate_polynomial_at_measuring_times(
 
 
 def evaluate_polynomial_at_measuring_time(
-        dataset: DataSet,
-        distance: float,
-        coefficients: np.ndarray,
+    dataset: DataSet,
+    distance: float,
+    coefficients: np.ndarray,
 ) -> np.ndarray:
     """
     Computes the sum of a polynomial evaluated at given time points.
@@ -58,18 +61,18 @@ def evaluate_polynomial_at_measuring_time(
     Returns:
         ndarray: Array of polynomial values evaluated at the given time points.
     """
-    
+
     if len(coefficients) == 0:
         raise PolynomialCoefficientError(
             "An empty array of coefficients can not be evaluated."
         )
-    
+
     time: float = calculate_time_from_distance_and_relative_velocity(dataset, distance)
     # Evaluate the polynomial sum at the given time points
     sum_at_measuring_distance: float = 0.0
     for exponent, coefficient in enumerate(coefficients):
         sum_at_measuring_distance += coefficient * pow(time, exponent)
-    
+
     return sum_at_measuring_distance
 
 
@@ -155,12 +158,14 @@ def calculate_polynomial_coefficients_for_tau_factor(
         ndarray: Array of polynomial coefficients for the tau factor.
     """
 
-    def polynomial_fit (x, *coefficients):
+    def polynomial_fit(x, *coefficients):
         # ensure that there is no zero in the coefficients to avoid division by zero
         if 0 in coefficients:
             for i in range(len(coefficients)):
                 if coefficients[i] == 0:
-                    coefficients = tuple(list(coefficients[:i]) + [1e-10] + list(coefficients[i+1:]))
+                    coefficients = tuple(
+                        list(coefficients[:i]) + [1e-10] + list(coefficients[i + 1 :])
+                    )
         return (
             np.poly1d(coefficients)(x) / np.polyder(np.poly1d(coefficients))(x)
         ) - tau_factor

--- a/napytau/core/tau.py
+++ b/napytau/core/tau.py
@@ -1,7 +1,7 @@
+import numpy as np
 from napytau.core.polynomials import (
     evaluate_differentiated_polynomial_at_measuring_times,
-)  # noqa E501
-import numpy as np
+)
 from napytau.import_export.model.dataset import DataSet
 
 
@@ -27,9 +27,10 @@ def calculate_tau_i_values(
     """
 
     # calculate decay times using the optimized coefficients
-    tau_i_values: np.ndarray = (
-        dataset.get_datapoints().get_unshifted_intensities().get_values()
-        / evaluate_differentiated_polynomial_at_measuring_times(dataset, coefficients)
+    tau_i_values: (
+        np.ndarray
+    ) = dataset.get_datapoints().get_unshifted_intensities().get_values() / evaluate_differentiated_polynomial_at_measuring_times(
+        dataset, coefficients
     )
 
     return tau_i_values

--- a/napytau/core/tau_simple.py
+++ b/napytau/core/tau_simple.py
@@ -42,7 +42,7 @@ def calc_tau_simple(dataset: DataSet) -> np.ndarray:
         )
 
         differential_shifted_mean[i] = (
-            intensities_shifted[i + 1] - intensities_unshifted[i]
+            intensities_shifted[i + 1] - intensities_shifted[i]
         ) / (flight_times[i + 1] - flight_times[i])
         differential_shifted_mean_uncertainties[i] = np.sqrt(
             (1 / (flight_times[i + 1] - flight_times[i]) ** 2)

--- a/napytau/core/tau_simple.py
+++ b/napytau/core/tau_simple.py
@@ -1,0 +1,30 @@
+import numpy as np
+from napytau.import_export.model.dataset import DataSet
+from napytau.core.time import calculate_times_from_distances_and_relative_velocity
+
+
+def calc_tau_simple(dataset: DataSet) -> np.ndarray:
+    intensities_unshifted = (
+        dataset.get_datapoints().get_unshifted_intensities().get_values()
+    )
+    intensities_shifted = (
+        dataset.get_datapoints().get_shifted_intensities().get_values()
+    )
+    distances = dataset.get_datapoints().get_distances().get_values()
+    flight_times = calculate_times_from_distances_and_relative_velocity(dataset)
+
+    unshifted_mean = np.empty((len(intensities_unshifted) - 1))
+    differential_shifted_mean = np.empty((len(intensities_shifted) - 1))
+    for i in range(len(intensities_unshifted) - 1):
+        unshifted_mean[i] = 0.5 * (
+            intensities_unshifted[i + 1] + intensities_unshifted[i]
+        )
+
+        differential_shifted_mean[i] = (
+            intensities_shifted[i + 1] - intensities_unshifted[i]
+        ) / (flight_times[i + 1] - flight_times[i])
+
+    tau_simple_values = unshifted_mean / differential_shifted_mean
+    tau_simple = np.mean(tau_simple_values)
+
+    return tau_simple

--- a/napytau/core/tau_simple.py
+++ b/napytau/core/tau_simple.py
@@ -1,10 +1,12 @@
 import numpy as np
+from typing import Tuple
 
 from napytau.import_export.model.dataset import DataSet
 from napytau.core.time import calculate_times_from_distances_and_relative_velocity
 
 
-def calc_tau_simple(dataset: DataSet) -> np.ndarray:
+def _prepare_intensity_arrays(dataset):
+    """Return the normalised peak areas and their uncertainties as intensity arrays."""
     normalisation_factors = dataset.get_datapoints().get_calibrations().get_values()
     normalisation_factors_uncertainties = (
         dataset.get_datapoints().get_calibrations().get_errors()
@@ -41,11 +43,109 @@ def calc_tau_simple(dataset: DataSet) -> np.ndarray:
         )
         ** 2
     )
-    distances = dataset.get_datapoints().get_distances().get_values()
     flight_times = calculate_times_from_distances_and_relative_velocity(dataset)
 
-    unshifted_mean_uncertainties = np.empty((len(intensities_unshifted) - 1))
+    return (
+        intensities_unshifted,
+        intensities_unshifted_uncertainties,
+        intensities_shifted,
+        intensities_shifted_uncertainties,
+        flight_times,
+    )
+
+
+def calc_tau_simple(dataset) -> Tuple[float, float]:
+    """
+    Calculate tau_simple the same way as napatau does using lambda.
+
+    This reproduces results of napatau by the "calc_tau_simple" function or clicking
+    the "tau simple button" in its GUI.
+    The decay constants lambda are calculated for each distance. Then the weighted mean
+    is calculated and afterwards inverted to get the final mean value for the lifetime.
+    """
+    (
+        intensities_unshifted,
+        intensities_unshifted_uncertainties,
+        intensities_shifted,
+        intensities_shifted_uncertainties,
+        flight_times,
+    ) = _prepare_intensity_arrays(dataset)
+
+    n_pairs = len(intensities_unshifted) - 1
+    unshifted_mean = np.empty(n_pairs)
+    unshifted_mean_uncertainties = np.empty(n_pairs)
+    differential_shifted_mean = np.empty(n_pairs)
+    differential_shifted_mean_uncertainties = np.empty(n_pairs)
+    lambda_decay_constant = np.empty(n_pairs)
+    lambda_decay_constant_uncertainty = np.empty(n_pairs)
+
+    for i in range(n_pairs):
+        unshifted_mean[i] = 0.5 * (
+            intensities_unshifted[i + 1] + intensities_unshifted[i]
+        )
+        unshifted_mean_uncertainties[i] = np.sqrt(
+            0.25
+            * (
+                intensities_unshifted_uncertainties[i + 1] ** 2
+                + intensities_unshifted_uncertainties[i] ** 2
+            )
+        )
+
+        dt = flight_times[i + 1] - flight_times[i]
+        differential_shifted_mean[i] = (
+            intensities_shifted[i + 1] - intensities_shifted[i]
+        ) / dt
+        differential_shifted_mean_uncertainties[i] = np.sqrt(
+            (1.0 / dt) ** 2
+            * (
+                intensities_shifted_uncertainties[i + 1] ** 2
+                + intensities_shifted_uncertainties[i] ** 2
+            )
+        )
+
+        lambda_decay_constant[i] = differential_shifted_mean[i] / unshifted_mean[i]
+        lambda_decay_constant_uncertainty[i] = np.sqrt(
+            (differential_shifted_mean_uncertainties[i] / unshifted_mean[i]) ** 2
+            + (
+                differential_shifted_mean[i]
+                * unshifted_mean_uncertainties[i]
+                / (unshifted_mean[i] ** 2)
+            )
+            ** 2
+        )
+
+    weights = 1.0 / (lambda_decay_constant_uncertainty**2)
+    weights_sum = np.sum(weights)
+    lambda_mean = np.sum(weights * lambda_decay_constant) / weights_sum
+    lambda_mean_err = 1.0 / np.sqrt(weights_sum)
+
+    tau_simple = 1.0 / lambda_mean
+    tau_simple_uncertainty = (1.0 / lambda_mean**2) * lambda_mean_err
+
+    return tau_simple, tau_simple_uncertainty
+
+
+def calc_tau_simple_alternative(dataset: DataSet) -> Tuple[float, float]:
+    """
+    Alternative tau_simple calculation.
+
+    Calculate tau_simple directly from tau and not via lambda.
+    This gives significantly different results since 1/x is non-linear:
+        mean[τ] = mean[1/λ] ≠ 1/mean[λ]
+    Napatau calculates first the mean of all λ_i and then averages it. This is different
+    as calculating the average of τ_i. Which approach is more physical is out of scope
+    of this implementation. Discussions regarding this topic are welcome.
+    """
+    (
+        intensities_unshifted,
+        intensities_unshifted_uncertainties,
+        intensities_shifted,
+        intensities_shifted_uncertainties,
+        flight_times,
+    ) = _prepare_intensity_arrays(dataset)
+
     unshifted_mean = np.empty((len(intensities_unshifted) - 1))
+    unshifted_mean_uncertainties = np.empty((len(intensities_unshifted) - 1))
     differential_shifted_mean = np.empty((len(intensities_shifted) - 1))
     differential_shifted_mean_uncertainties = np.empty((len(intensities_shifted) - 1))
     for i in range(len(intensities_unshifted) - 1):

--- a/napytau/core/tau_simple.py
+++ b/napytau/core/tau_simple.py
@@ -1,30 +1,63 @@
 import numpy as np
+
 from napytau.import_export.model.dataset import DataSet
 from napytau.core.time import calculate_times_from_distances_and_relative_velocity
 
 
 def calc_tau_simple(dataset: DataSet) -> np.ndarray:
+    normalisation_factors = dataset.get_datapoints().get_calibrations().get_values()
     intensities_unshifted = (
         dataset.get_datapoints().get_unshifted_intensities().get_values()
+        * normalisation_factors
+    )
+    intensities_unshifted_uncertainties = (
+        dataset.get_datapoints().get_unshifted_intensities().get_errors()
+        * normalisation_factors
     )
     intensities_shifted = (
         dataset.get_datapoints().get_shifted_intensities().get_values()
+        * normalisation_factors
+    )
+    intensities_shifted_uncertainties = (
+        dataset.get_datapoints().get_shifted_intensities().get_errors()
+        * normalisation_factors
     )
     distances = dataset.get_datapoints().get_distances().get_values()
     flight_times = calculate_times_from_distances_and_relative_velocity(dataset)
 
+    unshifted_mean_uncertainties = np.empty((len(intensities_unshifted) - 1))
     unshifted_mean = np.empty((len(intensities_unshifted) - 1))
     differential_shifted_mean = np.empty((len(intensities_shifted) - 1))
+    differential_shifted_mean_uncertainties = np.empty((len(intensities_shifted) - 1))
     for i in range(len(intensities_unshifted) - 1):
         unshifted_mean[i] = 0.5 * (
             intensities_unshifted[i + 1] + intensities_unshifted[i]
+        )
+        unshifted_mean_uncertainties[i] = np.sqrt(
+            0.25
+            * (
+                intensities_unshifted_uncertainties[i + 1] ** 2
+                + intensities_unshifted_uncertainties[i] ** 2
+            )
         )
 
         differential_shifted_mean[i] = (
             intensities_shifted[i + 1] - intensities_unshifted[i]
         ) / (flight_times[i + 1] - flight_times[i])
+        differential_shifted_mean_uncertainties[i] = np.sqrt(
+            (1 / (flight_times[i + 1] - flight_times[i]) ** 2)
+            * (intensities_shifted[i + 1] ** 2 + intensities_shifted[i] ** 2)
+        )
 
     tau_simple_values = unshifted_mean / differential_shifted_mean
-    tau_simple = np.mean(tau_simple_values)
+    tau_simple_uncertainties = np.sqrt(
+        (unshifted_mean_uncertainties / differential_shifted_mean) ** 2
+        + (differential_shifted_mean * unshifted_mean / differential_shifted_mean**2)
+        ** 2
+    )
+    tau_simple = np.average(tau_simple_values, weights=1 / tau_simple_uncertainties**2)
+    tau_simple_uncertainty = np.sqrt(np.sum(tau_simple_uncertainties**2)) / len(
+        tau_simple_uncertainties
+    )
 
-    return tau_simple
+    return tau_simple, tau_simple_uncertainty

--- a/napytau/core/tau_simple.py
+++ b/napytau/core/tau_simple.py
@@ -6,21 +6,40 @@ from napytau.core.time import calculate_times_from_distances_and_relative_veloci
 
 def calc_tau_simple(dataset: DataSet) -> np.ndarray:
     normalisation_factors = dataset.get_datapoints().get_calibrations().get_values()
+    normalisation_factors_uncertainties = (
+        dataset.get_datapoints().get_calibrations().get_errors()
+    )
     intensities_unshifted = (
         dataset.get_datapoints().get_unshifted_intensities().get_values()
         * normalisation_factors
     )
-    intensities_unshifted_uncertainties = (
-        dataset.get_datapoints().get_unshifted_intensities().get_errors()
-        * normalisation_factors
+    intensities_unshifted_uncertainties = np.sqrt(
+        (
+            dataset.get_datapoints().get_unshifted_intensities().get_errors()
+            * normalisation_factors
+        )
+        ** 2
+        + (
+            normalisation_factors_uncertainties
+            * dataset.get_datapoints().get_unshifted_intensities().get_values()
+        )
+        ** 2
     )
     intensities_shifted = (
         dataset.get_datapoints().get_shifted_intensities().get_values()
         * normalisation_factors
     )
-    intensities_shifted_uncertainties = (
-        dataset.get_datapoints().get_shifted_intensities().get_errors()
-        * normalisation_factors
+    intensities_shifted_uncertainties = np.sqrt(
+        (
+            dataset.get_datapoints().get_shifted_intensities().get_errors()
+            * normalisation_factors
+        )
+        ** 2
+        + (
+            dataset.get_datapoints().get_shifted_intensities().get_values()
+            * normalisation_factors_uncertainties
+        )
+        ** 2
     )
     distances = dataset.get_datapoints().get_distances().get_values()
     flight_times = calculate_times_from_distances_and_relative_velocity(dataset)
@@ -44,20 +63,28 @@ def calc_tau_simple(dataset: DataSet) -> np.ndarray:
         differential_shifted_mean[i] = (
             intensities_shifted[i + 1] - intensities_shifted[i]
         ) / (flight_times[i + 1] - flight_times[i])
+
         differential_shifted_mean_uncertainties[i] = np.sqrt(
-            (1 / (flight_times[i + 1] - flight_times[i]) ** 2)
-            * (intensities_shifted[i + 1] ** 2 + intensities_shifted[i] ** 2)
+            (1 / (flight_times[i + 1] - flight_times[i])) ** 2
+            * (
+                intensities_shifted_uncertainties[i + 1] ** 2
+                + intensities_shifted_uncertainties[i] ** 2
+            )
         )
 
     tau_simple_values = unshifted_mean / differential_shifted_mean
     tau_simple_uncertainties = np.sqrt(
         (unshifted_mean_uncertainties / differential_shifted_mean) ** 2
-        + (differential_shifted_mean * unshifted_mean / differential_shifted_mean**2)
+        + (
+            differential_shifted_mean_uncertainties
+            * unshifted_mean
+            / differential_shifted_mean**2
+        )
         ** 2
     )
-    tau_simple = np.average(tau_simple_values, weights=1 / tau_simple_uncertainties**2)
-    tau_simple_uncertainty = np.sqrt(np.sum(tau_simple_uncertainties**2)) / len(
-        tau_simple_uncertainties
+    tau_simple, sum_of_weights = np.average(
+        tau_simple_values, weights=1 / tau_simple_uncertainties**2, returned=True
     )
+    tau_simple_uncertainty = 1 / np.sqrt(sum_of_weights)
 
     return tau_simple, tau_simple_uncertainty

--- a/napytau/core/tau_simple.py
+++ b/napytau/core/tau_simple.py
@@ -1,5 +1,8 @@
-import numpy as np
+"""Calculate tau simple without any fitting as the same option in Napatau."""
+
 from typing import Tuple
+import numpy as np
+
 
 from napytau.import_export.model.dataset import DataSet
 from napytau.core.time import calculate_times_from_distances_and_relative_velocity

--- a/napytau/headless/headless_mockup.py
+++ b/napytau/headless/headless_mockup.py
@@ -73,8 +73,10 @@ def init(cli_arguments: CLIArguments) -> None:
             print(f"  Optimal Lifetime: {opt_lifetime} Error: {opt_err}")
             print("=" * 80)
             if cli_arguments.is_simple_tau():
-                tau_simple = calc_tau_simple(dataset)
-                print(f"Tau simple calculation: {tau_simple}")
+                tau_simple, tau_simple_uncertainty = calc_tau_simple(dataset)
+                print(
+                    f"Tau simple calculation: {tau_simple} +- {tau_simple_uncertainty}"
+                )
         setup_file_path = cli_arguments.get_setup_identifier()
         if setup_file_path is not None:
             for dataset in datasets:

--- a/napytau/headless/headless_mockup.py
+++ b/napytau/headless/headless_mockup.py
@@ -2,8 +2,11 @@ from pathlib import PurePath
 from typing import List
 
 from napytau.cli.cli_arguments import CLIArguments
-from napytau.core.core import calculate_lifetime_for_custom_tau_factor, calculate_lifetime_for_fit, \
-    calculate_optimal_tau_factor
+from napytau.core.core import (
+    calculate_lifetime_for_custom_tau_factor,
+    calculate_lifetime_for_fit,
+    calculate_optimal_tau_factor,
+)
 from napytau.import_export.import_export import (
     IMPORT_FORMAT_LEGACY,
     IMPORT_FORMAT_NAPYTAU,
@@ -14,6 +17,7 @@ from napytau.import_export.import_export import (
 )
 from napytau.import_export.model.dataset import DataSet
 from napytau.util.coalesce import coalesce
+from napytau.core.tau_simple import calc_tau_simple
 
 
 def init(cli_arguments: CLIArguments) -> None:
@@ -52,20 +56,25 @@ def init(cli_arguments: CLIArguments) -> None:
                 )
                 print(f"    Active:  {datapoint.is_active()} ")
                 print("-" * 80)
-            
+
             (lifetime, err) = calculate_lifetime_for_fit(dataset, 3)
             print(f"  Lifetime: {lifetime} Error: {err}")
-            
+
             optimal_tau_factor = calculate_optimal_tau_factor(
                 dataset=dataset,
                 t_hyp_range=(0.0, 100.0),
                 weight_factor=1,
                 polynomial_degree=3,
             )
-            
-            (opt_lifetime, opt_err) = calculate_lifetime_for_custom_tau_factor(dataset, optimal_tau_factor, 1)
+
+            (opt_lifetime, opt_err) = calculate_lifetime_for_custom_tau_factor(
+                dataset, optimal_tau_factor, 1
+            )
             print(f"  Optimal Lifetime: {opt_lifetime} Error: {opt_err}")
             print("=" * 80)
+            if cli_arguments.is_simple_tau():
+                tau_simple = calc_tau_simple(dataset)
+                print(f"Tau simple calculation: {tau_simple}")
         setup_file_path = cli_arguments.get_setup_identifier()
         if setup_file_path is not None:
             for dataset in datasets:
@@ -93,9 +102,8 @@ def init(cli_arguments: CLIArguments) -> None:
                     print(f"    Active:  {datapoint.is_active()} ")
                     print("-" * 80)
         for dataset in datasets:
-                print("=" * 80)
-                
-        
+            print("=" * 80)
+
     elif cli_arguments.get_dataset_format() == IMPORT_FORMAT_NAPYTAU:
         setup_files_directory_path = cli_arguments.get_data_files_directory_path()
         setup_identifier = cli_arguments.get_setup_identifier()

--- a/napytau/headless/headless_mockup.py
+++ b/napytau/headless/headless_mockup.py
@@ -72,11 +72,12 @@ def init(cli_arguments: CLIArguments) -> None:
             )
             print(f"  Optimal Lifetime: {opt_lifetime} Error: {opt_err}")
             print("=" * 80)
-            if cli_arguments.is_simple_tau():
+            if cli_arguments.is_tau_simple():
                 tau_simple, tau_simple_uncertainty = calc_tau_simple(dataset)
                 print(
                     f"Tau simple calculation: {tau_simple} +- {tau_simple_uncertainty}"
                 )
+
         setup_file_path = cli_arguments.get_setup_identifier()
         if setup_file_path is not None:
             for dataset in datasets:

--- a/tests/core/tau_simple_test.py
+++ b/tests/core/tau_simple_test.py
@@ -1,0 +1,103 @@
+import unittest
+from unittest.mock import patch
+import numpy as np
+from napytau.core.tau_simple import calc_tau_simple
+
+
+class TauSimpleUnitTests(unittest.TestCase):
+    def test_calc_tau_simple(self):
+        """Test tau_simple with values from 132Te dataset."""
+        intensities_unshifted = np.array(
+            [
+                1177.15468035,
+                1094.40000617,
+                1310.11130973,
+                1384.08781108,
+                1270.4635517,
+                1138.74900115,
+                1127.98060615,
+                1197.39865685,
+                1056.74890986,
+                757.00387421,
+                626.36091347,
+                306.53948207,
+            ]
+        )
+        intensities_unshifted_unc = np.array(
+            [
+                80.98796399,
+                73.73576285,
+                73.72799963,
+                77.74673988,
+                67.90963276,
+                61.94946441,
+                70.47992774,
+                79.60007913,
+                71.82884912,
+                60.20154397,
+                60.13362304,
+                85.50112313,
+            ]
+        )
+        intensities_shifted = np.array(
+            [
+                269.55163934,
+                368.04142396,
+                128.33227064,
+                133.05031147,
+                284.86936634,
+                138.26256226,
+                329.70887352,
+                229.27332962,
+                833.34860094,
+                580.09553565,
+                785.13065263,
+                1003.70968423,
+            ]
+        )
+        intensities_shifted_unc = np.array(
+            [
+                84.39238958,
+                77.1037839,
+                73.87649544,
+                76.90126852,
+                69.31586135,
+                64.20747153,
+                73.97034696,
+                82.65020657,
+                82.68776247,
+                70.84063257,
+                72.96506007,
+                115.24693167,
+            ]
+        )
+        flight_times = np.array(
+            [
+                1.82184202e-12,
+                3.83668109e-12,
+                6.07538868e-12,
+                1.05527367e-11,
+                1.50300623e-11,
+                2.51042129e-11,
+                6.54004570e-11,
+                8.77873986e-11,
+                1.24725592e-10,
+                1.80692700e-10,
+                2.47853950e-10,
+                3.37399276e-10,
+            ]
+        )
+
+        with patch("napytau.core.tau_simple._prepare_intensity_arrays") as mock_prep:
+            mock_prep.return_value = (
+                intensities_unshifted,
+                intensities_unshifted_unc,
+                intensities_shifted,
+                intensities_shifted_unc,
+                flight_times,
+            )
+
+            result = calc_tau_simple(dataset=None)
+
+        self.assertAlmostEqual(result[0], 3.57017089e-10, delta=1e-14)
+        self.assertAlmostEqual(result[1], 1.32525943e-10, delta=1e-14)


### PR DESCRIPTION
<!-- Please remove any superfluous sections before submitting the pull request! -->

### Summary

Add a tau simple calculation which is also present in napatau. It does not fit anything but calculates the slope with a triangle between two neighbouring datapoints. The data in the unittest taken from 132Te data gives the same result that are calculated by napatau. So the result could be reproduced. 
An alternative approach is also provided in calc_tau_simple_alternative which calculates the lifetime from the single lifetime and averages them. Napatau originally calculates lambda first, averages it and then takes the inverse to get the mean lifetime. This is a non-linear process and therefore not equivalent. Which approach is more physical is still to be discussed.

Tau simple can be invoked in headless mode
```bash
uvx tomlscript run --headless --data_files_directory Testdaten --tau_simple
```

---

### PR checklist

-  x] I have written tests that fail without my changes. _Or I did not add them on purpose._
- [x] I have included instructions on how to test this, assuming they are not already apparent from the linked issue.

---

I would be very happy to get feedback on the coding part from @Benedikt-Brunner or @Madddiiiin , if your time allows.