### PR TITLE
Rename calibration to normalisation

### DIFF
--- a/napytau/core/tau_simple.py
+++ b/napytau/core/tau_simple.py
@@ -10,9 +10,9 @@ from napytau.core.time import calculate_times_from_distances_and_relative_veloci
 
 def _prepare_intensity_arrays(dataset):
     """Return the normalised peak areas and their uncertainties as intensity arrays."""
-    normalisation_factors = dataset.get_datapoints().get_calibrations().get_values()
+    normalisation_factors = dataset.get_datapoints().get_normalisations().get_values()
     normalisation_factors_uncertainties = (
-        dataset.get_datapoints().get_calibrations().get_errors()
+        dataset.get_datapoints().get_normalisations().get_errors()
     )
     intensities_unshifted = (
         dataset.get_datapoints().get_unshifted_intensities().get_values()

--- a/napytau/headless/headless_mockup.py
+++ b/napytau/headless/headless_mockup.py
@@ -42,8 +42,8 @@ def init(cli_arguments: CLIArguments) -> None:
                     f"Error: {datapoint.get_distance().error}"
                 )
                 print(
-                    f"    Calibration: Value: {datapoint.get_calibration().value} "
-                    f"Error: {datapoint.get_calibration().error}"
+                    f"    Normalisation: Value: {datapoint.get_normalisation().value} "
+                    f"Error: {datapoint.get_normalisation().error}"
                 )
                 shifted_intensity, unshifted_intensity = datapoint.get_intensity()
                 print(
@@ -137,8 +137,8 @@ def init(cli_arguments: CLIArguments) -> None:
                     f"Error: {datapoint.get_distance().error}"
                 )
                 print(
-                    f"    Calibration: Value: {datapoint.get_calibration().value} "
-                    f"Error: {datapoint.get_calibration().error}"
+                    f"    Normalisation: Value: {datapoint.get_normalisation().value} "
+                    f"Error: {datapoint.get_normalisation().error}"
                 )
                 shifted_intensity, unshifted_intensity = datapoint.get_intensity()
                 print(

--- a/napytau/import_export/crawler/legacy_setup_files.py
+++ b/napytau/import_export/crawler/legacy_setup_files.py
@@ -10,27 +10,27 @@ class LegacySetupFiles:
     distances_file: PurePath
     velocity_file: PurePath
     fit_file: PurePath
-    calibration_file: PurePath
+    normalisation_file: PurePath
 
     def __init__(
         self,
         distances_file: PurePath,
         velocity_file: PurePath,
         fit_file: PurePath,
-        calibration_file: PurePath,
+        normalisation_file: PurePath,
     ):
         """Use the static constructor method instead"""
         self.distances_file = distances_file
         self.velocity_file = velocity_file
         self.fit_file = fit_file
-        self.calibration_file = calibration_file
+        self.normalisation_file = normalisation_file
 
     @staticmethod
     def create_from_file_names(file_paths: List[PurePath]) -> LegacySetupFiles:
         distances_file: PurePath
         velocity_file: PurePath
         fit_file: PurePath
-        calibration_file: PurePath
+        normalisation_file: PurePath
         missing_files = []
 
         try:
@@ -51,7 +51,7 @@ class LegacySetupFiles:
             missing_files.append("fit")
 
         try:
-            calibration_file = next(
+            normalisation_file = next(
                 file for file in file_paths if "norm.fac" in file.name
             )
         except StopIteration:
@@ -64,5 +64,5 @@ class LegacySetupFiles:
             )
 
         return LegacySetupFiles(
-            distances_file, velocity_file, fit_file, calibration_file
+            distances_file, velocity_file, fit_file, normalisation_file
         )

--- a/napytau/import_export/factory/legacy/legacy_factory.py
+++ b/napytau/import_export/factory/legacy/legacy_factory.py
@@ -25,7 +25,7 @@ class LegacyFactory:
             LegacyFactory.parse_velocity(raw_dataset.velocity_rows),
             LegacyFactory.parse_datapoints(
                 raw_dataset.distance_rows,
-                raw_dataset.calibration_rows,
+                raw_dataset.normalisation_rows,
                 raw_dataset.fit_rows,
             ),
         )
@@ -65,19 +65,19 @@ class LegacyFactory:
     @staticmethod
     def parse_datapoints(
         distance_rows: List[str],
-        calibration_rows: List[str],
+        normalisation_rows: List[str],
         fit_rows: List[str],
     ) -> DatapointCollection:
         datapoints = DatapointCollection([])
         for distance_row in distance_rows:
             distance = LegacyFactory.parse_distance_row(distance_row)
             datapoints.add_datapoint(Datapoint(distance))
-        for calibration_row in calibration_rows:
-            (distance_index, calibration) = LegacyFactory.parse_calibration_row(
-                calibration_row
+        for normalisation_row in normalisation_rows:
+            (distance_index, normalisation) = LegacyFactory.parse_normalisation_row(
+                normalisation_row
             )
             datapoint = datapoints.get_datapoint_by_distance(distance_index)
-            datapoint.set_calibration(calibration)
+            datapoint.set_normalisation(normalisation)
         for fit_row in fit_rows:
             (
                 distance_index,
@@ -118,25 +118,25 @@ class LegacyFactory:
         return ValueErrorPair(distance, distance_error)
 
     @staticmethod
-    def parse_calibration_row(
-        calibration_row: str,
+    def parse_normalisation_row(
+        normalisation_row: str,
     ) -> Tuple[float, ValueErrorPair[float]]:
-        split_row = calibration_row.split(" ")
+        split_row = normalisation_row.split(" ")
         if len(split_row) < 3:
             raise ValueError(
-                f"Expected at least 3 values in calibration row, but got {len(split_row)}"  # noqa E501
+                f"Expected at least 3 values in normalisation row, but got {len(split_row)}"  # noqa E501
             )
 
         if len(split_row) > 3:
             raise ValueError(
-                f"Expected at most 3 values in calibration row, but got {len(split_row)}"  # noqa E501
+                f"Expected at most 3 values in normalisation row, but got {len(split_row)}"  # noqa E501
             )
 
         distance_index = float(split_row[0])
-        calibration = float(split_row[1])
-        calibration_error = float(split_row[2])
+        normalisation = float(split_row[1])
+        normalisation_error = float(split_row[2])
 
-        return distance_index, ValueErrorPair(calibration, calibration_error)
+        return distance_index, ValueErrorPair(normalisation, normalisation_error)
 
     @staticmethod
     def parse_fit_row(

--- a/napytau/import_export/factory/legacy/raw_legacy_data.py
+++ b/napytau/import_export/factory/legacy/raw_legacy_data.py
@@ -7,4 +7,4 @@ class RawLegacyData:
     velocity_rows: List[str]
     distance_rows: List[str]
     fit_rows: List[str]
-    calibration_rows: List[str]
+    normalisation_rows: List[str]

--- a/napytau/import_export/factory/napytau/json_service/napytau_format_json_service.py
+++ b/napytau/import_export/factory/napytau/json_service/napytau_format_json_service.py
@@ -38,14 +38,14 @@ _SCHEMA = """
             "description": "The error in the distance between the particles",
             "minimum": 0
           },
-          "calibration": {
+          "normalisation": {
             "type": "number",
-            "description": "The calibration factor for the data point",
+            "description": "The normalisation factor for the data point",
             "minimum": 0
           },
-          "calibrationError": {
+          "normalisationError": {
             "type": "number",
-            "description": "The error in the calibration factor for the data point",
+            "description": "The error in the normalisation factor for the data point",
             "minimum": 0
           },
           "shiftedIntensity": {
@@ -94,8 +94,8 @@ _SCHEMA = """
         "required": [
           "distance",
           "distanceError",
-          "calibration",
-          "calibrationError",
+          "normalisation",
+          "normalisationError",
           "shiftedIntensity",
           "shiftedIntensityError",
           "unshiftedIntensity",

--- a/napytau/import_export/factory/napytau/napytau_factory.py
+++ b/napytau/import_export/factory/napytau/napytau_factory.py
@@ -34,9 +34,9 @@ class NapyTauFactory:
                 coalesce(raw_datapoint.get("distance")),
                 coalesce(raw_datapoint.get("distanceError")),
             )
-            calibration = ValueErrorPair(
-                coalesce(raw_datapoint.get("calibration")),
-                coalesce(raw_datapoint.get("calibrationError")),
+            normalisation = ValueErrorPair(
+                coalesce(raw_datapoint.get("normalisation")),
+                coalesce(raw_datapoint.get("normalisationError")),
             )
             shifted_intensity = ValueErrorPair(
                 coalesce(raw_datapoint.get("shiftedIntensity")),
@@ -63,7 +63,7 @@ class NapyTauFactory:
             datapoints.append(
                 Datapoint(
                     distance,
-                    calibration,
+                    normalisation,
                     shifted_intensity,
                     unshifted_intensity,
                     feeding_shifted_intensity,

--- a/napytau/import_export/import_export.py
+++ b/napytau/import_export/import_export.py
@@ -51,7 +51,7 @@ def import_legacy_format_from_files(
                     FileReader.read_rows(setup_files.velocity_file),
                     FileReader.read_rows(setup_files.distances_file),
                     FileReader.read_rows(setup_files.fit_file),
-                    FileReader.read_rows(setup_files.calibration_file),
+                    FileReader.read_rows(setup_files.normalisation_file),
                 )
             ),
             setup_file_bundles,

--- a/napytau/import_export/model/datapoint.py
+++ b/napytau/import_export/model/datapoint.py
@@ -17,7 +17,7 @@ class Datapoint:
     """
 
     distance: ValueErrorPair[float]
-    calibration: Optional[ValueErrorPair[float]] = None
+    normalisation: Optional[ValueErrorPair[float]] = None
     shifted_intensity: Optional[ValueErrorPair[float]] = None
     unshifted_intensity: Optional[ValueErrorPair[float]] = None
     feeding_shifted_intensity: Optional[ValueErrorPair[float]] = None
@@ -31,14 +31,14 @@ class Datapoint:
     def set_distance(self, distance: ValueErrorPair[float]) -> None:
         self.distance = distance
 
-    def get_calibration(self) -> ValueErrorPair[float]:
-        if self.calibration is None:
-            raise ValueError("Calibration was accessed before initialization.")
+    def get_normalisation(self) -> ValueErrorPair[float]:
+        if self.normalisation is None:
+            raise ValueError("Normalisation was accessed before initialization.")
 
-        return self.calibration
+        return self.normalisation
 
-    def set_calibration(self, calibration: ValueErrorPair[float]) -> None:
-        self.calibration = calibration
+    def set_normalisation(self, normalisation: ValueErrorPair[float]) -> None:
+        self.normalisation = normalisation
 
     def get_intensity(self) -> Tuple[ValueErrorPair[float], ValueErrorPair[float]]:
         if self.shifted_intensity is None or self.unshifted_intensity is None:

--- a/napytau/import_export/model/datapoint_collection.py
+++ b/napytau/import_export/model/datapoint_collection.py
@@ -62,13 +62,13 @@ class DatapointCollection:
             )
         )
 
-    def get_calibrations(self) -> ValueErrorPairCollection[float]:
+    def get_normalisations(self) -> ValueErrorPairCollection[float]:
         return ValueErrorPairCollection(
             list(
                 map(
-                    lambda datapoint: coalesce(datapoint.calibration),
+                    lambda datapoint: coalesce(datapoint.normalisation),
                     self.filter(
-                        lambda datapoint: datapoint.calibration is not None
+                        lambda datapoint: datapoint.normalisation is not None
                     ).elements.values(),
                 )
             )

--- a/tests/import_export/crawler/legacy_setup_files_test.py
+++ b/tests/import_export/crawler/legacy_setup_files_test.py
@@ -55,7 +55,7 @@ class LegacySetupFilesUnitTest(unittest.TestCase):
         self.assertEqual(setup_files.distances_file, PurePath("distances.dat"))
         self.assertEqual(setup_files.velocity_file, PurePath("v_c"))
         self.assertEqual(setup_files.fit_file, PurePath("test.fit"))
-        self.assertEqual(setup_files.calibration_file, PurePath("norm.fac"))
+        self.assertEqual(setup_files.normalisation_file, PurePath("norm.fac"))
 
 
 if __name__ == "__main__":

--- a/tests/import_export/factory/napatau/legacy_factory_test.py
+++ b/tests/import_export/factory/napatau/legacy_factory_test.py
@@ -65,8 +65,8 @@ class LegacyFactoryUnitTest(unittest.TestCase):
                 )
             )
 
-    def test_raisesAnExceptionIfACalibrationRowWithTooFewValuesIsProvided(self):
-        """Raises an exception if a calibration row with too few values is provided"""
+    def test_raisesAnExceptionIfANormalisationRowWithTooFewValuesIsProvided(self):
+        """Raises an exception if a normalisation row with too few values is provided"""
         with self.assertRaises(ValueError):
             LegacyFactory.create_dataset(
                 RawLegacyData(
@@ -77,8 +77,8 @@ class LegacyFactoryUnitTest(unittest.TestCase):
                 )
             )
 
-    def test_raisesAnExceptionIfACalibrationRowWithTooManyValuesIsProvided(self):
-        """Raises an exception if a calibration row with too many values is provided"""
+    def test_raisesAnExceptionIfANormalisationRowWithTooManyValuesIsProvided(self):
+        """Raises an exception if a normalisation row with too many values is provided"""
         with self.assertRaises(ValueError):
             LegacyFactory.create_dataset(
                 RawLegacyData(
@@ -148,10 +148,10 @@ class LegacyFactoryUnitTest(unittest.TestCase):
             dataset.datapoints.get_datapoint_by_distance(1).distance.error, 1
         )
         self.assertEqual(
-            dataset.datapoints.get_datapoint_by_distance(1).calibration.value, 1
+            dataset.datapoints.get_datapoint_by_distance(1).normalisation.value, 1
         )
         self.assertEqual(
-            dataset.datapoints.get_datapoint_by_distance(1).calibration.error, 1
+            dataset.datapoints.get_datapoint_by_distance(1).normalisation.error, 1
         )
         self.assertEqual(
             dataset.datapoints.get_datapoint_by_distance(1).shifted_intensity.value, 1
@@ -187,10 +187,10 @@ class LegacyFactoryUnitTest(unittest.TestCase):
             dataset.datapoints.get_datapoint_by_distance(1).distance.error, 1
         )
         self.assertEqual(
-            dataset.datapoints.get_datapoint_by_distance(1).calibration.value, 1
+            dataset.datapoints.get_datapoint_by_distance(1).normalisation.value, 1
         )
         self.assertEqual(
-            dataset.datapoints.get_datapoint_by_distance(1).calibration.error, 1
+            dataset.datapoints.get_datapoint_by_distance(1).normalisation.error, 1
         )
         self.assertEqual(
             dataset.datapoints.get_datapoint_by_distance(1).shifted_intensity.value, 1

--- a/tests/import_export/factory/napytau/napytau_factory_test.py
+++ b/tests/import_export/factory/napytau/napytau_factory_test.py
@@ -70,8 +70,8 @@ class NapytauFactoryUnitTest(unittest.TestCase):
                     {
                         "distance": 1,
                         "distanceError": 0.1,
-                        "calibration": 1,
-                        "calibrationError": 0.1,
+                        "normalisation": 1,
+                        "normalisationError": 0.1,
                         "shiftedIntensity": 1,
                         "shiftedIntensityError": 0.1,
                         "unshiftedIntensity": 1,
@@ -87,8 +87,8 @@ class NapytauFactoryUnitTest(unittest.TestCase):
             self.assertEqual(len(dataset.datapoints), 1)
             self.assertEqual(dataset.datapoints[0].distance.value, 1)
             self.assertEqual(dataset.datapoints[0].distance.error, 0.1)
-            self.assertEqual(dataset.datapoints[0].calibration.value, 1)
-            self.assertEqual(dataset.datapoints[0].calibration.error, 0.1)
+            self.assertEqual(dataset.datapoints[0].normalisation.value, 1)
+            self.assertEqual(dataset.datapoints[0].normalisation.error, 0.1)
             self.assertEqual(dataset.datapoints[0].shifted_intensity.value, 1)
             self.assertEqual(dataset.datapoints[0].shifted_intensity.error, 0.1)
             self.assertEqual(dataset.datapoints[0].unshifted_intensity.value, 1)
@@ -122,8 +122,8 @@ class NapytauFactoryUnitTest(unittest.TestCase):
                     {
                         "distance": 1,
                         "distanceError": 0.1,
-                        "calibration": 1,
-                        "calibrationError": 0.1,
+                        "normalisation": 1,
+                        "normalisationError": 0.1,
                         "shiftedIntensity": 1,
                         "shiftedIntensityError": 0.1,
                         "unshiftedIntensity": 1,
@@ -143,8 +143,8 @@ class NapytauFactoryUnitTest(unittest.TestCase):
             self.assertEqual(len(dataset.datapoints), 1)
             self.assertEqual(dataset.datapoints[0].distance.value, 1)
             self.assertEqual(dataset.datapoints[0].distance.error, 0.1)
-            self.assertEqual(dataset.datapoints[0].calibration.value, 1)
-            self.assertEqual(dataset.datapoints[0].calibration.error, 0.1)
+            self.assertEqual(dataset.datapoints[0].normalisation.value, 1)
+            self.assertEqual(dataset.datapoints[0].normalisation.error, 0.1)
             self.assertEqual(dataset.datapoints[0].shifted_intensity.value, 1)
             self.assertEqual(dataset.datapoints[0].shifted_intensity.error, 0.1)
             self.assertEqual(dataset.datapoints[0].unshifted_intensity.value, 1)

--- a/tests/import_export/import_export_test.py
+++ b/tests/import_export/import_export_test.py
@@ -235,7 +235,7 @@ class IngestUnitTest(unittest.TestCase):
             ["v_c_row"],
             ["distances.dat_row"],
             ["fit_row"],
-            ["calibration_row"],
+            ["normalisation_row"],
         ]
 
         with patch.dict(
@@ -274,8 +274,8 @@ class IngestUnitTest(unittest.TestCase):
             self.assertEqual(
                 legacy_factory_module_mock.LegacyFactory.create_dataset.mock_calls[0]
                 .args[0]
-                .calibration_rows,
-                ["calibration_row"],
+                .normalisation_rows,
+                ["normalisation_row"],
             )
 
     def test_callsTheLegacyFactoryWithTheRawLegacyDataIfAFitFileIsProvided(
@@ -305,7 +305,7 @@ class IngestUnitTest(unittest.TestCase):
             ["v_c_row"],
             ["distances.dat_row"],
             ["fit_row"],
-            ["calibration_row"],
+            ["normalisation_row"],
         ]
 
         with patch.dict(
@@ -347,8 +347,8 @@ class IngestUnitTest(unittest.TestCase):
             self.assertEqual(
                 legacy_factory_module_mock.LegacyFactory.create_dataset.mock_calls[0]
                 .args[0]
-                .calibration_rows,
-                ["calibration_row"],
+                .normalisation_rows,
+                ["normalisation_row"],
             )
 
     def test_usesTheFileReaderToReadTheRowsFromTheProvidedSetupFilePathWhenReadingLegacySetupData(

--- a/tests/import_export/model/datapoint_collection_test.py
+++ b/tests/import_export/model/datapoint_collection_test.py
@@ -177,17 +177,17 @@ class DatapointCollectionUnitTest(unittest.TestCase):
             ),
         )
 
-    def test_canRetrieveCalibrations(self):
-        """Can retrieve calibrations"""
+    def test_canRetrieveNormalisations(self):
+        """Can retrieve normalisations"""
         collection = DatapointCollection(
             [
                 Datapoint(
                     distance=ValueErrorPair(12.12, 0.1),
-                    calibration=ValueErrorPair(1.0, 0.1),
+                    normalisation=ValueErrorPair(1.0, 0.1),
                 ),
                 Datapoint(
                     distance=ValueErrorPair(12.13, 0.1),
-                    calibration=ValueErrorPair(2.0, 0.1),
+                    normalisation=ValueErrorPair(2.0, 0.1),
                 ),
                 Datapoint(
                     distance=ValueErrorPair(12.14, 0.1),
@@ -196,7 +196,7 @@ class DatapointCollectionUnitTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            collection.get_calibrations(),
+            collection.get_normalisations(),
             ValueErrorPairCollection(
                 [ValueErrorPair(1.0, 0.1), ValueErrorPair(2.0, 0.1)]
             ),

--- a/tests/import_export/model/datapoint_test.py
+++ b/tests/import_export/model/datapoint_test.py
@@ -4,11 +4,11 @@ from napytau.util.model.value_error_pair import ValueErrorPair
 
 
 class DatapointUnitTest(unittest.TestCase):
-    def test_raisesAnExceptionIfCalibrationIsAccessedBeforeInitialization(self):
-        """Raise an exception if calibration is accessed before initialization."""
+    def test_raisesAnExceptionIfNormalisationIsAccessedBeforeInitialization(self):
+        """Raise an exception if normalisation is accessed before initialization."""
         datapoint = Datapoint(ValueErrorPair(1.0, 0.1))
         with self.assertRaises(Exception):
-            datapoint.get_calibration()
+            datapoint.get_normalisation()
 
     def test_raisesAnExceptionIfIntensityIsAccessedBeforeInitialization(self):
         """Raise an exception if intensity is accessed before initialization."""


### PR DESCRIPTION
Closes #72

Since no calibration is performed in the code—only a normalisation is applied—this renames all functions, fields, parameters, and JSON schema keys containing `calibration` to `normalisation`.

### Renames

- **Model**: `Datapoint.calibration` field → `normalisation`; `get_calibration`/`set_calibration` → `get_normalisation`/`set_normalisation`; `DatapointCollection.get_calibrations` → `get_normalisations`
- **Legacy parsing**: `RawLegacyData.calibration_rows` → `normalisation_rows`; `LegacyFactory.parse_calibration_row` → `parse_normalisation_row`; `LegacySetupFiles.calibration_file` → `normalisation_file`
- **NapyTau JSON**: schema keys `calibration`/`calibrationError` → `normalisation`/`normalisationError` (breaking change to the on-disk JSON format)
- **Callers**: `tau_simple.py`, `headless_mockup.py`, `import_export.py`
- **Tests**: all corresponding test files updated

### Notes

- This branch is based on `core/tau_simple` (PR #71) since that PR introduced `tau_simple.py` which references `get_calibrations`. After #71 merges into main, the diff here will reduce to just the rename commit.
- Legacy file name `norm.fac` is unchanged (external file format).