### PR TITLE
ci: run on all non-draft PRs regardless of target branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -25,6 +25,7 @@ jobs:
 
   run-static-analysis:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -39,6 +40,7 @@ jobs:
 
   run-tests:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Why

Currently the `pull_request` trigger in [.github/workflows/ci.yml](.github/workflows/ci.yml) is filtered to PRs whose base branch is `main`:

```yaml
pull_request:
  branches:
    - main
```

This means PRs targeting any other branch (e.g. long-lived feature branches like `core/task/refactor-calculation` in #71) get **no CI runs at all** — no lint, no static analysis, no tests. The restriction has been in place since the workflow was first introduced in #5 (Nov 2024).

## What

- Drop the `branches` filter on the `pull_request` trigger so CI runs for every PR regardless of target branch.
- Add `types: [opened, synchronize, reopened, ready_for_review]` so the workflow re-triggers when a draft PR is marked ready for review.
- Add a job-level `if` guard on each job so draft PRs do not consume CI minutes:
  ```yaml
  if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
  ```
- `push` to `main` behavior is unchanged.